### PR TITLE
ci: reduce action runs (PR-only triggers, drop py3.12 matrix, monthly…

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -2,7 +2,7 @@ name: Backend CI
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
     paths:
       - "backend/**"
       - "pyproject.toml"
@@ -17,9 +17,12 @@ concurrency:
   group: backend-ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
-  lint:
-    name: Ruff (lint + format)
+  ci:
+    name: Lint & Test (Python 3.13)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -27,43 +30,16 @@ jobs:
         with:
           python-version: "3.13"
           cache: "pip"
-          cache-dependency-path: "backend/requirements-dev.txt"
-      - name: Install dev tooling
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r backend/requirements-dev.txt
-      - name: ruff check
-        run: ruff check backend
-      - name: ruff format --check
-        run: ruff format --check backend
-
-  test:
-    name: pytest (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.12", "3.13"]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
           cache-dependency-path: |
             backend/requirements.txt
             backend/requirements-dev.txt
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r backend/requirements.txt
-          pip install -r backend/requirements-dev.txt
-      - name: Run pytest with coverage
-        run: pytest backend/tests --cov=backend --cov-report=xml --cov-report=term-missing
-      - name: Upload coverage artifact
-        if: matrix.python-version == '3.13'
-        uses: actions/upload-artifact@v6
-        with:
-          name: backend-coverage
-          path: coverage.xml
-          retention-days: 14
+          pip install -r backend/requirements.txt -r backend/requirements-dev.txt
+      - name: Ruff (lint + format)
+        run: |
+          ruff check backend
+          ruff format --check backend
+      - name: Pytest with coverage
+        run: pytest backend/tests --cov=backend --cov-report=term-missing

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -2,7 +2,7 @@ name: Frontend CI
 
 on:
   push:
-    branches: ["**"]
+    branches: ["main"]
     paths:
       - "frontend/**"
       - ".github/workflows/frontend-ci.yml"
@@ -15,13 +15,16 @@ concurrency:
   group: frontend-ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: frontend/Vue
 
 jobs:
-  build:
-    name: Lint, Test & Build
+  ci:
+    name: Lint, Test & Build (Node 22)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -30,27 +33,12 @@ jobs:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: frontend/Vue/package-lock.json
-
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
-
       - name: Lint
         run: npm run lint
         continue-on-error: true
-
-      - name: Format check
-        run: npm run format:check
-        continue-on-error: true
-
       - name: Run tests
         run: npm test
-
       - name: Build
         run: npm run build
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: frontend-build
-          path: frontend/Vue/dist
-          retention-days: 7

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,17 +1,23 @@
 name: Security
 
 on:
-  push:
-    branches: ["main", "master"]
   pull_request:
-    branches: ["main", "master"]
+    branches: ["main"]
   schedule:
-    # Run weekly on Monday at 00:00 UTC
-    - cron: "0 0 * * 1"
+    # First day of each month at 03:00 UTC
+    - cron: "0 3 1 * *"
+  workflow_dispatch:
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   codeql:
-    name: CodeQL Analysis
+    name: CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -24,19 +30,12 @@ jobs:
         language: ["python", "javascript"]
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+      - uses: actions/checkout@v6
+      - uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/autobuild@v4
+      - uses: github/codeql-action/analyze@v4
         with:
-          category: "/language:${{matrix.language}}"
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
… CodeQL)

- backend-ci: single job (lint+test+coverage), python 3.13 only, push only on main, paths filter unchanged

- frontend-ci: single job, push only on main, no upload-artifact, no format:check

- security: monthly cron + pull_request to main + workflow_dispatch (was: push+PR+weekly)

- add 'permissions: contents: read' to all workflows